### PR TITLE
Use shallow clones by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The next step is to get the script onto Cisco DNA Center.  There are four ways o
 If you have access to the internet from DNAC, can clone the repository (containing the executable)
 
 ```
-git clone https://github.com/CiscoDevNet/DNAC-AURA.git
+git clone --depth=1 https://github.com/CiscoDevNet/DNAC-AURA.git
 ```
 ### Option 2. git clone via proxy
 If DNAC needs a proxy to get to the internet, you will need to provide a proxy for git command.
@@ -28,7 +28,7 @@ NOTE:  please do not set a permanent environment variable as this will stop you 
 
 The example below uses an inline environment variable, just for the git command.  Make sure to put in the correct proxy url (including port) 
 ```
-https_proxy=https://<your proxy> git clone https://github.com/CiscoDevNet/DNAC-AURA.git
+https_proxy=https://<your proxy> git clone --depth=1 https://github.com/CiscoDevNet/DNAC-AURA.git
 ```
 
 ### Option 3. Isolated environment.  
@@ -54,7 +54,7 @@ It is likely there is a transparent proxy in the way.  In order to work around t
 ```
 echo -n | openssl s_client -showcerts -connect github.com:443 2>/dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /home/maglev/git.pem
 
-git config --global http."https://github.com:443/".sslCAInfo/home/maglev/git.pem
+git config --global http."https://github.com:443/".sslCAInfo /home/maglev/git.pem
 ```
 you then should be able to use git clone as normal.
 
@@ -65,11 +65,11 @@ $ cd ./DNAC-AURA
 $ git pull
 ```
 
-##AURA Versions - Change Log
+## AURA Versions - Change Log
 For release updates, see ChangeLog.md
 
 https://github.com/CiscoDevNet/DNAC-AURA/blob/master/ChangeLog.md
- 
+
 
 
 ## To Run


### PR DESCRIPTION
This repository manages large binary files, so cloning everything is a waste of time. By using shallow clones, downloading can be done **3 times faster**. 🚀

This difference will become more significant as more and more commits are made in the future.

## Deep clone

```
$ time git clone https://github.com/CiscoDevNet/DNAC-AURA.git DNAC-AURA-deep-clone
Cloning into 'DNAC-AURA-deep-clone'...
remote: Enumerating objects: 567, done.
remote: Counting objects: 100% (565/565), done.
remote: Compressing objects: 100% (206/206), done.
Receiving objects: 100% (567/567), 65.36 MiB | 1.29 MiB/s, done.
remote: Total 567 (delta 356), reused 563 (delta 355), pack-reused 2
Resolving deltas: 100% (356/356), done.

real	0m54.169s
user	0m2.060s
sys	0m3.187s

$ du -h -d 0 DNAC-AURA-deep-clone
 93M	DNAC-AURA-deep-clone
```

## Shallow clone

```
$ time git clone --depth=1 https://github.com/CiscoDevNet/DNAC-AURA.git DNAC-AURA-shallow-clone
Cloning into 'DNAC-AURA-shallow-clone'...
remote: Enumerating objects: 12, done.
remote: Counting objects: 100% (12/12), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 12 (delta 1), reused 3 (delta 0), pack-reused 0
Receiving objects: 100% (12/12), 8.79 MiB | 497.00 KiB/s, done.
Resolving deltas: 100% (1/1), done.

real	0m20.618s
user	0m0.351s
sys	0m0.508s

$ du -h -d 0 DNAC-AURA-shallow-clone
 22M	DNAC-AURA-shallow-clone
```

This PR also fixes some minor typos.